### PR TITLE
Check if libcloud is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Clone elibcloud and start it from the shell:
     $ make
     $ erl -pa ../elibcloud/ebin -pa deps/goldrush/ebin -pa deps/jsx/ebin -pa deps/lager/ebin
     > application:start(syntax_tools).
+    > application:start(compiler).
     > application:start(goldrush).
     > application:start(lager).
 

--- a/README.md
+++ b/README.md
@@ -159,3 +159,14 @@ See the edoc documentation of the exported functions in
 [hp-cloud]: https://horizon.hpcloud.com/
 [rackspace]: https://mycloud.rackspace.com/
 [elibcloud.erl]: https://github.com/esl/elibcloud/blob/master/src/elibcloud.erl
+
+
+### FAQ
+
+**I cannot use elibcloud on Mac OS X because I get the "No CA Certificates were found in CA_CERTS_PATH" run-time error. How can I solve this?**
+
+On Mac OS X, I have fixed this by installing `curl-ca-bundle`. You can install it using `brew`.
+
+```sh
+brew install curl-ca-bundle
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the `PATH` is the same as the one that has Libcloud installed.
 Clone elibcloud and start it from the shell:
 
     $ git clone git@github.com:esl/elibcloud.git
-    $ cd elarm
+    $ cd elibcloud
     $ make
     $ erl -pa ../elibcloud/ebin -pa deps/goldrush/ebin -pa deps/jsx/ebin -pa deps/lager/ebin
     > application:start(syntax_tools).

--- a/priv/libcloud_check.py
+++ b/priv/libcloud_check.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+#=============================================================================
+# Copyright (C) 2014, Erlang Solutions Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+import sys
+
+try:
+    import libcloud
+except ImportError:
+    sys.exit(1)

--- a/src/elibcloud.erl
+++ b/src/elibcloud.erl
@@ -41,6 +41,8 @@
                               <<"RACKSPACE">>,
                               <<"DUMMY">>]).
 
+-define(TIMEOUT_LIBCLOUD_CHECK, 500).
+
 %%------------------------------------------------------------------------------
 %% Types
 %%------------------------------------------------------------------------------
@@ -69,6 +71,21 @@
                           Port     :: tcp | udp | icmp}.
 
 -opaque credentials() :: json_term().
+
+%%------------------------------------------------------------------------------
+%% Sanity check
+%%------------------------------------------------------------------------------
+-on_load(ensure_libcloud_is_installed/0).
+
+ensure_libcloud_is_installed() ->
+    Script = filename:join([code:priv_dir(elibcloud), "libcloud_check.py"]),
+    Port = open_port({spawn_executable, Script}, [exit_status]),
+    receive
+        {Port, {exit_status, 0}} ->
+            ok
+    after ?TIMEOUT_LIBCLOUD_CHECK ->
+            throw(libcloud_not_found)
+    end.
 
 %%%=============================================================================
 %%% External functions


### PR DESCRIPTION
This PR implements a safeguard that checks if libcloud is installed (or reachable).

The sanity check is performed when the elibcloud is first loaded (using the -on_load(function) directive).

Before this patch, this is the error I got when I tried to use elibcloud and libcloud was not properly installed on my computer:

```
...CRASH REPORT Process <0.1544.0> with 0 neighbours exited with reason: no case clause matching 127 in elibcloud:libcloud_wrapper/1 line 505 in gen_server:terminate/6 line 746...
```

This is the error one gets now:

```
=ERROR REPORT==== 3-Jun-2014::09:39:58 ===
Error in process <0.34.0> with exit value: {{nocatch,libcloud_not_found},[{elibcloud,ensure_libcloud_is_installed,0,[{file,"src/elibcloud.erl"},{line,87}]},{code_server,'-handle_on_load/4-fun-0-',1,[{file,"code_server.erl"},{line,1656}]}]}
```

Besides getting a more intuitive error message, the timing has also been improved. As mentioned earlier, the error is now thrown the first time elibcloud is used (e.g. when creating the credentials), rather than waiting until the user calls a function triggering a call to libcloud.
